### PR TITLE
New keybinding to move client to relative tag

### DIFF
--- a/rice/bindings/client.lua
+++ b/rice/bindings/client.lua
@@ -68,7 +68,31 @@ local client_bindings = {
             end
         end,
     },
-
+    
+    binding.new {
+        modifiers = { mod.super, mod.shift },
+        triggers = {
+            { trigger = "Left", action = -1 },
+            { trigger = "Right", action = 1 },
+        },
+        path = { "Tag", "Client" },
+        description = "Move client to previous/next tag",
+        on_press = function(trigger, client)
+            -- Get current tag
+            local current_tag = client.screen.selected_tags[1]
+            -- Set new tag reference index
+            local tag = client.screen.tags[current_tag.index + trigger.action]
+            if tag then
+                -- Move client
+                client:move_to_tag(tag)
+                -- Switch to 'tag' and select client to maintain focus
+                tag.selected = true
+                current_tag.selected = false
+                client.selected = true
+            end
+        end,
+    },
+    
     binding.new {
         modifiers = { mod.control, mod.super, mod.shift },
         triggers = binding.group.numrow,
@@ -204,7 +228,6 @@ local client_bindings = {
         description = "Keep on all tags (sticky)",
         on_press = function(_, client) client.sticky = not client.sticky end,
     },
-
 }
 
 return client_bindings


### PR DESCRIPTION
Added new keybinding in rice/bindings/client.lua that builds upon the existing keybinding of 'Move to tag'. 

This moves the focused client to the tag immediately previous or next in the `client.screen.tags[]` array. The client move does not wrap around to the start or end of the array if already at the end or start.

This new keybinding uses the trigger: arrow left/right instead of numrow with the same modifiers `{ mod.super, mod.shift }`